### PR TITLE
Replace PgInterval With A Single Interval

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,18 @@
+const MONTHS_TO_YEAR: i32 = 12;
+const MICROS_TO_HOUR: i64 = 3600000000;
+const MICROS_TO_MINUTE: i64 = 60000000;
+const MICROS_TO_SECOND: i64 = 1000000;
+
+pub fn get_year_month_interval(months: i32) -> (i32, i8) {
+    let years: i32 = months/MONTHS_TO_YEAR;
+    let months: i8 = (months - (years * MONTHS_TO_YEAR)) as i8;
+    (years, months)
+}
+
+pub fn get_day_time_interval(microseconds: i64) -> (i64, i8, f64) {
+    let hours: i64 = microseconds/MICROS_TO_HOUR;
+    let current_hours: i64 = hours * MICROS_TO_HOUR;
+    let minutes: i64 = (microseconds - current_hours)/MICROS_TO_MINUTE;
+    let seconds: f64 = (microseconds - (current_hours+(minutes * MICROS_TO_MINUTE))) as f64/MICROS_TO_SECOND as f64;
+    (hours, minutes as i8, seconds)
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -16,3 +16,59 @@ pub fn get_day_time_interval(microseconds: i64) -> (i64, i8, f64) {
     let seconds: f64 = (microseconds - (current_hours+(minutes * MICROS_TO_MINUTE))) as f64/MICROS_TO_SECOND as f64;
     (hours, minutes as i8, seconds)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn negative_year_month_interval() {
+        let months = i32::min_value();
+        let (years, months) = get_year_month_interval(months);
+        assert!(years == -178956970);
+        assert!(months == -8);
+    }
+
+    #[test]
+    fn positive_year_month_interval() {
+        let months = i32::max_value();
+        let (years, months) = get_year_month_interval(months);
+        assert!(years == 178956970);
+        assert!(months == 7);
+    }
+
+    #[test]
+    fn negative_day_time_interval() {
+        let microseconds = -7199000000;
+        let (hours, minutes, seconds) = get_day_time_interval(microseconds);
+        assert!(hours == -1);
+        assert!(minutes == -59);
+        assert!(seconds == -59.0);
+    }
+
+    #[test]
+    fn postive_day_time_interval() {
+        let microseconds = 7199000000;
+        let (hours, minutes, seconds) = get_day_time_interval(microseconds);
+        assert!(hours == 1);
+        assert!(minutes == 59);
+        assert!(seconds == 59.0);
+    }
+
+    #[test]
+    fn day_time_remaining_milliseconds() {
+        let microseconds = 7199001000;
+        let (hours, minutes, seconds) = get_day_time_interval(microseconds);
+        assert!(hours == 1);
+        assert!(minutes == 59);
+        assert!(seconds == 59.001);
+    }
+
+    #[test]
+    fn day_time_remaining_millisecond() {
+        let microseconds = 7199000001;
+        let (hours, minutes, seconds) = get_day_time_interval(microseconds);
+        assert!(hours == 1);
+        assert!(minutes == 59);
+        assert!(seconds == 59.000001);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,79 @@
-#[derive(Debug)]
-/// The wire format that postgres sends intervals in. Shouldn't be used directly.
-pub struct PgInterval {
-  months: i32
-  days: i32,
-  microseconds: i64,
+mod helpers;
+
+use helpers::*;
+
+pub struct Interval {
+    years: i32,
+    months: i8,
+    days: i32,
+    hours: i64,
+    minutes: i8,
+    seconds: f64
 }
 
-impl PgInterval {
-    /// Construct a new instance of a PgInterval.
-    pub fn new(months: i32, days: i32, microseconds: i64) -> PgInterval {
-        PgInterval {
+impl Interval {
+    pub fn new(years: i32,
+               months: i8,
+               days: i32,
+               hours: i64,
+               minutes: i8,
+               seconds: f64) -> Interval {
+        Interval {
+            years: years,
             months: months,
             days: days,
-            microseconds: days
+            hours: hours,
+            minutes: minutes,
+            seconds: seconds
+        }
+    }
+
+
+    /// Get the amount of years that the interval spans.
+    pub fn get_years(&self) -> i32 {
+        self.years
+    }
+
+    /// Get the amount of months that the interval spans.
+    pub fn get_months(&self) -> i8 {
+        self.months
+    }
+
+    /// Get the amount of days that the interval spans.
+    pub fn get_days(&self) -> i32 {
+        self.days
+    }
+
+    /// Get the amount of hourss that the interval spans.
+    pub fn get_hours(&self) -> i64 {
+        self.hours
+    }
+
+    /// Get the amount of minutes that the interval spans.
+    pub fn get_minutes(&self) -> i8 {
+        self.minutes
+    }
+
+    /// Get the amount of seconds that the interval spans. Anything smaller
+    /// than a seconds is represented fractionally.
+    pub fn get_seconds(&self) -> f64 {
+        self.seconds
+    }
+
+    /// Map interval formats that use months, days, and microseconds to Interval.
+    pub fn from_months_days_microseconds(months: i32,
+                                        days: i32,
+                                        microseconds: i64)
+                                         -> Interval {
+        let (years,months) = get_year_month_interval(months);
+        let (hours, minutes, seconds) = get_day_time_interval(microseconds);
+        Interval {
+            years: years,
+            months: months,
+            days: days,
+            hours: hours,
+            minutes: minutes,
+            seconds: seconds
         }
     }
 }


### PR DESCRIPTION
Adds helper functions to help map interval formats that use month, day, microseconds as a means to represent the interval format. 